### PR TITLE
Add practical document AI blog post

### DIFF
--- a/posts/20260331-practical-doc-ai/index.qmd
+++ b/posts/20260331-practical-doc-ai/index.qmd
@@ -1,0 +1,349 @@
+---
+title: "Learnings from a Decade of Document AI Work"
+date: 2026-03-31
+categories: [ai, multimodal, document ai, ml systems]
+format:
+  html:
+    toc: true
+    toc-depth: 2
+---
+
+For most of the last decade, I kept running into the same business problem wearing different clothes: turn messy documents into reliable structured decisions.
+
+Sometimes the documents were forms. Sometimes they were invoices, onboarding packets, statements, or tax documents. The inputs changed. The models changed. The hype changed even faster. But the operational demand stayed remarkably constant: read what matters, understand enough structure and context, map the result into a schema, and do it reliably enough that an actual business process can depend on it.
+
+That is the lens I want to use in this post. Not "here is the history of document AI" in the abstract, and not "look how much benchmarks improved." I mean something narrower and more practical: how the stack changed when you were the person trying to make document understanding work on real inputs with deadlines, edge cases, and annoyed users.
+
+::: {.callout-note appearance="simple"}
+## TL;DR
+
+- Early document AI systems were dominated by templates, OCR, and heuristics. They worked well in narrow settings and failed badly under variation.
+- Detector-first deep learning systems improved robustness on the visual side, but often turned the stack into a brittle multi-stage pipeline.
+- Layout-aware transformers mattered because they learned to combine OCR text, geometry, and image cues more directly, but they still depended heavily on task-specific labeled data.
+- Foundation models changed the economics and architecture of the system again. The bottleneck is now less about whether a model can read a document and more about orchestration, validation, and evaluation.
+- Practical document AI still is not one model. It is a composed system.
+:::
+
+| Phase | Dominant stack | What improved | What became painful |
+| --- | --- | --- | --- |
+| Templates and heuristics | Templates, registration, cropped OCR, rules | Fast wins on narrow stable forms | Template drift, registration failures, OCR brittleness |
+| Detector-first pipelines | Object detectors plus OCR plus postprocessing | Better visual robustness and localization | Labeling burden, detector-OCR handoff, error propagation |
+| Layout-aware transformers | OCR text plus layout plus image cues in one model | Easier supervision, stronger field extraction | Task-specific data prep, specialized models, single-page limits |
+| Foundation-model systems | OCR, VLMs, LLMs, validators, routing, post-training | Faster prototyping, stronger generalization, richer reasoning | Orchestration, confidence policy, evaluation, OOD robustness |
+
+## The problem never was just OCR
+
+People sometimes talk about document AI as if it were synonymous with OCR. OCR is part of it, but in production it was never the whole game.
+
+The real job usually looked more like this:
+
+- find the relevant regions or fields
+- recover text from noisy scans, photos, or PDFs
+- infer structure from layout
+- connect information across multiple fields or pages
+- normalize the result into a business schema
+- validate that the extracted values are internally consistent
+- decide when the system should ask for human review
+
+That last point matters more than most benchmark papers suggest. A document system is only useful when it knows when not to trust itself.
+
+## How we measured success
+
+In client projects, the metric that mattered most was usually field-level accuracy.
+
+That sounds simple until you try to evaluate real business documents. Often there is not exactly one canonical string answer. Addresses can be broken into lines in multiple valid ways. Dates may appear in more than one acceptable format. OCR may introduce harmless whitespace or punctuation differences. So field-level evaluation usually needed normalization logic and some task-aware intelligence in the evaluator rather than a naive string equality check.
+
+That field-level view then rolled up into the metric that mattered most to the business: automation quality. In practice this usually meant two coupled numbers:
+
+- what percentage of work can be automated
+- among the automatically processed cases, what is the error rate
+
+That is a policy problem as much as a modeling problem. Document AI systems make many small decisions, and the automation policy depends on confidence score thresholds or other confidence signals. If the confidence module is poor, the automation policy is poor even if the raw model is good.
+
+So in practice, I came to think about evaluation in layers:
+
+- **Field-level accuracy:** the primary task metric, usually with normalization and problem-specific matching logic
+- **Automation coverage:** the percentage of documents or fields the system chooses to automate
+- **Automation precision:** the error rate among automated decisions
+- **Review rate:** how often the system falls back to a human
+- **Threshold behavior:** how those numbers move as confidence thresholds change
+
+Depending on the problem, there were also standard supporting metrics:
+
+- **Character error rate (CER)** and **word error rate (WER):** still useful for OCR quality, often computed with edit distance
+- **Entity-level precision / recall / F1:** common for key information extraction and semantic entity recognition
+- **ANLS (Average Normalized Levenshtein Similarity):** widely used in DocVQA-style string-answer tasks when near-matches should get partial credit
+- **mAP at IoU thresholds:** standard for layout detection and document object detection tasks
+- **TEDS / TEDS-Struct:** useful for table structure recognition, where exact tree structure matters more than flat token overlap
+
+There is also a broader lesson here. The right metric depends on the shape of the downstream decision. For forms and contracts, field-level correctness may dominate. For OCR-heavy systems, CER and WER may still be useful diagnostics. For receipts and invoices, line-item structure may require entity F1 or table-structure metrics. For automation systems, the most important chart is often not a single benchmark score but a coverage-versus-error curve under the confidence policy.
+
+That is why I am skeptical of one-number evaluations in document AI. The system is not just trying to be correct in the abstract. It is trying to support a decision policy.
+
+## Phase 1: templates, OCR, and heuristics
+
+My early mental model of document AI was straightforward: if a document class is stable enough, you can solve a lot with templates, image registration, OCR, and rules.
+
+That stack typically looked like this:
+
+- develop a template for the document family
+- register the input image against the template
+- crop expected field regions
+- run OCR over the cropped regions or the page
+- find anchor phrases like "Invoice Number" or "Gross Pay"
+- use coordinates, nearby tokens, regexes, and page-specific rules
+- map the result into a schema
+
+In a constrained workflow, this worked better than many people now remember. If the document family was narrow, the scan quality acceptable, the registration reliable enough, and the downstream schema stable, template-heavy systems could be fast, cheap, and surprisingly accurate.
+
+The downside was brittleness. Registration was never as reliable as one hoped once scans and photos became messy. Small layout shifts broke coordinate assumptions. A vendor changed a form revision and the parser quietly degraded. OCR errors propagated into every downstream rule. Handwriting, stamps, low-resolution scans, skew, or multi-page dependencies exposed how much of the system was really held together by assumptions.
+
+What I learned from that phase was that the problem was not merely reading text. The hard part was handling variation without rewriting the system every time a document changed shape.
+
+## Phase 2: detector-first pipelines
+
+The next major improvement came from better visual models. Instead of assuming we already knew where everything was, we trained or used detectors to find regions of interest: tables, signatures, key-value fields, checkboxes, logos, headers, or other structural elements.
+
+This was a real step forward. Even a moderately good detector could absorb a lot of the variability that broke template-only systems. Rather than hard-coding the location of a field, you could ask a model to find it. That reduced some of the worst coordinate brittleness and made the pipeline feel more adaptive.
+
+But the architecture was still very staged:
+
+- detect region
+- crop region
+- OCR region
+- parse OCR text
+- apply rules
+
+In other words, it was already multimodal in a loose engineering sense, but not in a unified learned sense. Vision handled localization. OCR handled text recognition. Rules and business logic handled interpretation.
+
+That decomposition was often the right choice for the tools of the time, but it came with painful handoff boundaries. If the detector missed the box, OCR never had a chance. If OCR garbled the crop, the parser failed. If table structure was slightly off, everything downstream became an exception case. As these systems got more capable, they also got more operationally complicated.
+
+The key lesson for me was that better perception did not automatically mean simpler systems. In many cases, it meant the opposite.
+
+### A concrete example from 2018: real estate contracts
+
+Around 2018, one of the document classes I worked on was real estate contracts. On paper, this sounds like a fairly standard extraction problem: find a set of predefined fields and map them into a structured schema. In practice, the awkwardness of the visual geometry dominated the work.
+
+The target workflow also mattered. We were mainly extracting from historical contracts to unlock analytics, rather than automating live contract intake where latency mattered more. Success was measured by field-level accuracy against manually entered ground truth on a sample set, with the usual caveat that even human-entered values were not perfectly clean.
+
+Some fields were tiny. A value like the option period might span only a couple of characters, occupying a tiny fraction of the page. Other fields were long and horizontally stretched, which made them a bad fit for the default anchor-box assumptions in detectors like RetinaNet. There were also multiline address fields, which introduced ambiguity even at the labeling stage. When does one field end? Should the line break be treated as part of the same value or as evidence of a different structural unit? Those details sound small, but they shape the whole training pipeline.
+
+The common pattern at the time was:
+
+- detect the field region with a visual model
+- crop the region
+- send the crop to a commercial OCR engine
+- parse and normalize the text
+
+The OCR layer was often a commercial API such as Google Vision and AWS OCR services. That stack was powerful enough to be useful, but it made the coupling between detection and OCR very obvious. If the detection box was off by a little, the OCR result degraded immediately. If the field was unusually thin or elongated, the detector could miss it for reasons that were architectural rather than semantic.
+
+Those elongated and tiny fields were a good example. Initially some of them had mAP around 20% even after training on tens of thousands of examples. Once we fixed the anchor-box setup for those geometries, they jumped to above 90% mAP. That was both encouraging and humbling: the model was not "bad at the task" in some abstract sense. It was badly matched to the object geometry we cared about.
+
+That project made me appreciate how much document AI depends on mundane geometric details. It was not enough to say "use a detector." You had to ask what shape of object the detector was biased toward, how small a target it could reliably localize, and how much labeling ambiguity you were inadvertently baking into the system.
+
+### Another example from 2020: receipt understanding
+
+Around 2020, colleagues of mine worked on receipt understanding. I was not directly on that project, but the engineering lessons were close enough to be instructive: production document problems are defined as much by acquisition noise as by semantics.
+
+Receipts are deceptively hard. The images often came from phone photos rather than clean scans, which meant weird viewing angles, blur, shadows, partial occlusion, and inconsistent lighting. Some receipts were long enough that users captured them in multiple photos, which introduced a stitching problem before extraction even began. And unlike a flat key-value form, the output schema had nested structure: line items sitting under subtotal and total, with all the ambiguity that implies.
+
+This kind of task exposed the limitations of thinking about document understanding as a sequence of isolated local predictions. You did not just need to read text. You needed to reconstruct a coherent object from messy visual evidence, impose structure on repeated rows, and keep the hierarchy of the output intact. Better preprocessing, including rectification and super-resolution, helped both detectors and OCR. Stitching multiple receipt images together added another large gain. It was a hard enough problem that outperforming strong specialist vendors on it was meaningful.
+
+## Phase 3: learning to combine cues
+
+The transition to layout-aware transformers is sometimes described too loosely as "document AI became multimodal." That is not quite right. Production systems were already combining visual signals and text. The more important change was this: the model itself began to treat text, geometry, and sometimes image features as jointly useful inputs for the same prediction problem.
+
+That mattered a lot.
+
+Models in the LayoutLM family and related approaches pushed the field toward learned fusion rather than hand-assembled coordination between separate components. Instead of a pipeline where OCR text and bounding boxes were merely intermediate artifacts passed between modules, the model could learn patterns like:
+
+- this token means something different depending on where it appears
+- nearby fields provide semantic context
+- document layout carries information that plain text alone loses
+- the same textual phrase can play different roles across forms
+
+This was the first time many document understanding tasks felt natively modeled rather than patched together.
+
+It also made clear what the new bottleneck was: data.
+
+These models were often much better once properly trained or fine-tuned, but they were not magic. You still needed labeled examples. You still needed annotation conventions. You still had to decide what exactly the prediction target was, how to deal with low-confidence spans, and how to retrain when the incoming mix of documents changed.
+
+So the pain shifted. In earlier systems, the pain was brittle rules. In this phase, the pain became dataset curation, labeling operations, task framing, and maintenance of specialized models.
+
+That was still progress. But it was progress with a clear bill attached.
+
+### A concrete example from 2022: LayoutLM-style models
+
+Around 2022, we adopted LayoutLM-type models for some of our work, and the experience changed my view of what "document understanding" could feel like in practice.
+
+The most refreshing part was not that the models were magically zero-shot. They were not. The most refreshing part was that the shape of the task changed. We could take image pixels plus OCR text as input and predict which OCR tokens were the answer to a question. That was a much more natural fit for many extraction problems than drawing and detecting field boxes first.
+
+Operationally, this often looked like a token-classification setup over OCR words. We did not need to hand-label bounding boxes for every target field region in the same way detector pipelines did. The manual labeling only needed to specify the final answer. From there, we built an inverse labeling process to project those answers back onto token-level supervision. That let us generate token labels from the final extracted values rather than asking annotators to do the more tedious span-by-span geometric work directly.
+
+That shift mattered. It materially reduced annotation burden because there was no more box labeling, made iteration faster, and let us train on more data. More importantly, the transformer layers could cross-reference signals in a way our older pipelines could not. Text content, token position, page layout, and visual context could all inform the prediction jointly. A word was no longer interpreted in isolation or only through a local detector crop. It could be interpreted in the context of the document.
+
+The models were larger, but the cost was acceptable. In practice, model inference time was still small compared with the rest of a real production pipeline: retrieving PDFs from data sources, querying multiple databases, and doing all the ordinary glue work around the model.
+
+That was the phase where I started feeling that the stack had become meaningfully more "document native."
+
+## Phase 4: foundation models changed the shape of the stack
+
+The latest wave feels different again.
+
+Modern OCR engines are much stronger than they used to be. Vision-language models can reason over pages more flexibly. Large language models are good at schema mapping, normalization, and conditional extraction. Long-context models make multi-page reasoning more tractable. Prompting, few-shot examples, and tool use often get you surprisingly far before any custom training enters the picture.
+
+The consequence is not simply that accuracy went up. The consequence is that the architecture of the system changed.
+
+For a growing set of document problems, you can now start from something like this:
+
+- extract text and page images
+- send the right representation to a VLM or LLM
+- ask for structured output in a target schema
+- run validators and business-rule checks
+- retry, route, or escalate when confidence is low
+
+That reduces the amount of task-specific modeling you need up front. It also makes previously annoying problems more approachable: fuzzy field definitions, cross-page references, lightweight reasoning, or documents that do not fit neatly into a single pre-trained template.
+
+But this shift creates a new trap. It is tempting to think the model has replaced the system.
+
+It has not.
+
+What changed is that more of the complexity moved upward into orchestration:
+
+- when to use OCR text, raw image, or both
+- which model to route a document to
+- how to enforce structured outputs
+- how to validate extracted values against business rules
+- when to re-prompt, when to fall back, and when to send to a human
+- how to measure regression when prompts, models, or providers change
+
+In older stacks, the fragility lived in templates and hand-tuned pipelines. In current stacks, the fragility often lives in orchestration and evaluation.
+
+### A concrete example from 2024 to 2026: multi-model systems and post-training
+
+What defined this phase for me was not replacing the old stack with a single foundation model. It was wiring together multiple models and utilities into a system that could make better use of each component's strengths.
+
+Across several projects, the stack often included:
+
+- a VLM for schema-informed extraction on single-page or small multi-page inputs
+- OCR for high-recall generic extraction
+- custom detectors for stamps, signatures, and other out-of-distribution visual objects
+- page classifiers
+- heuristic image-preprocessing modules
+- retrieval or knowledge utilities for context engineering
+- LLMs for cross-examining intermediate results from multiple models
+
+```{mermaid}
+flowchart LR
+    A[Document or PDF] --> B[Preprocessing\nrectify, enhance, split]
+    B --> C[OCR\nhigh-recall text extraction]
+    B --> D[VLM\nschema-informed extraction]
+    B --> E[Custom detectors\nstamps, signatures, OOD objects]
+    B --> F[Page classifier]
+    C --> G[Context engineering\nretrieval, business context]
+    D --> G
+    E --> G
+    F --> G
+    G --> H[LLM reconciliation\ncross-examine intermediate results]
+    H --> I[Validators and business rules]
+    I --> J[Confidence policy]
+    J -->|high confidence| K[Automated output]
+    J -->|low confidence| L[Field-level review]
+```
+
+This was powerful because the components were not interchangeable. OCR was often the recall-oriented layer. The VLM was useful when the extraction target depended on layout and semantic intent. Custom detectors still mattered for niche objects that general models handled unreliably. LLMs were useful not only for extraction, but for reconciling conflicting evidence across model outputs.
+
+That last point changed how I thought about the problem. In earlier pipelines, model outputs were often treated as final. In these newer systems, intermediate outputs became evidence that could be compared, challenged, and combined. A modern document pipeline can look less like a linear parser and more like a controlled cross-examination among specialized components.
+
+We also found that post-training still mattered.
+
+For some VLM use cases, supervised fine-tuning was useful both for getting a more desirable output format and for improving accuracy on inputs that were out of distribution relative to the base open-source model's training data. SFT was especially helpful for making the model emit cleaner, more usable structured outputs. It also helped on difficult inputs such as low-quality scans of forms, handwritten content, and unfamiliar formats like music sheets.
+
+But SFT had limits. It gave a good initial accuracy bump and improved formatting behavior, then started to plateau. The harder part was pushing beyond that plateau, which is where we spent a lot of time on RL with verifiable rewards. Getting RL to work reliably was much more demanding than getting SFT to work. Reward design, verification logic, training stability, and evaluation all mattered.
+
+So even in the foundation-model phase, the story was not "prompting replaced training." The more accurate story was that prompting widened the starting point, while post-training remained important when you cared about domain robustness, output discipline, and performance on ugly real-world inputs.
+
+This phase also made me appreciate how much leverage now comes from open ecosystems. A lot of this work was enabled by open-source tooling and models: Hugging Face Transformers, TRL, Unsloth, and Miles on the tooling side, and model families like Llama, Mistral, Qwen, and Nemotron on the modeling side. That ecosystem made it much easier to experiment with both orchestration and post-training, even if making the whole system production-grade still took real engineering discipline.
+
+So the foundational-model phase feels less like "the problem is solved" and more like "the design space got much larger." That is powerful, but only if the surrounding system is built to keep the models honest.
+
+## What wins now is composition
+
+If I had to summarize the biggest practical lesson from the last decade, it is this: document AI is still not a one-model problem.
+
+The strongest systems today are usually composed. They mix several ingredients:
+
+- OCR or native text extraction when available
+- image understanding for visual structure and ambiguous regions
+- language models for normalization, schema mapping, and reasoning
+- validators for checksums, totals, dates, identities, and business constraints
+- confidence estimation and failure routing
+- human review for the residual long tail
+
+This sounds less elegant than a pure end-to-end story, but it matches reality better.
+
+In business workflows, the goal is rarely to produce a plausible answer. The goal is to produce a trustworthy answer, or to fail in a way that the rest of the system can handle. A model that is very smart but poorly harnessed can be less useful than a narrower component inside a disciplined pipeline.
+
+In the systems we delivered, confidence policy usually relied less on any single model score and more on agreement and validation. Agreement across OCR, VLM, and LLM outputs was useful. Validator pass/fail was useful. Field-level review then focused on uncertain fields rather than sending whole documents to manual fallback. Over time, that review path should become increasingly infrequent, but it remains a critical part of the safety net.
+
+That is why I think the phrase "agentic document AI" is simultaneously useful and easy to misuse. The interesting part is not just that an agent can call multiple models. The interesting part is that the system can coordinate extraction, validation, re-checking, and exception handling in a controlled loop. If that loop is sloppy, you do not have a production system. You have an expensive demo.
+
+## The bottleneck kept moving
+
+Looking back, I think each phase mostly moved the bottleneck rather than eliminating it.
+
+- Template-heavy systems were bottlenecked by brittleness under variation.
+- Detector-first systems were bottlenecked by pipeline complexity and error propagation.
+- Layout-aware transformers were bottlenecked by labeled data and task-specific training.
+- Foundation-model systems are bottlenecked by orchestration, evaluation, and reliability.
+
+That is part of why this field remains interesting. It keeps changing, but it does not change by becoming simpler in some absolute sense. It changes by making one layer easier and exposing the next layer more clearly.
+
+The misconceptions also changed with the stack:
+
+- **Templates and heuristics:** if I keep adding templates, I can solve all document extraction problems. In reality, templates drift, scans are distorted or incomplete, and registration is much less reliable than it first appears.
+- **Detector-first pipelines:** if I tune the detector and the OCR separately, I am done. In reality, labeling is hard, the detector-OCR integration boundary is painful, and box quality itself becomes a source of downstream error.
+- **Layout-aware transformers:** if the model works on one document family and a few fields, I can reuse it broadly. In reality, these models are still fairly specialized and need new task data when the document or extraction target changes.
+- **Foundation models:** I can just throw documents at an API and get the answer. For simple tasks that is increasingly true. For messy, mission-critical extraction on large real documents, there is still a substantial gap.
+
+## What I believe now
+
+After working on practical document understanding problems for years, a few beliefs have become stronger for me.
+
+First, narrow systems still matter. General models are real progress, but boring domain constraints, validation logic, and carefully designed fallbacks still do a huge amount of the actual work.
+
+Second, benchmark wins and production wins are not the same thing. A model can look impressive on a public task and still be awkward in a real workflow where documents are incomplete, mislabeled, duplicated, rotated, partially photographed, or mixed with irrelevant pages.
+
+Third, data work never went away. Even when you do not fine-tune models, you still need curated evaluation sets, failure analysis, representative samples, and some discipline around measuring change.
+
+Fourth, the most important property of a document system is often not raw intelligence. It is calibrated reliability.
+
+## If I were starting a new document AI project today
+
+I would begin much more pragmatically than I would have ten years ago.
+
+I would start with a narrow workflow, pick a high-quality OCR path and a strong general multimodal model, define the output schema tightly, and add validators early. I would build an evaluation set before I built a large custom modeling effort. I would study the failure distribution before deciding whether the next step should be prompting, routing, fine-tuning, better OCR, or a human-in-the-loop review path.
+
+Most importantly, I would resist the temptation to ask a single model to do everything.
+
+The field has changed enormously. But the underlying production question still feels familiar: how do you turn messy documents into dependable decisions?
+
+The answer, then as now, is not a single breakthrough. It is the discipline of building systems that combine perception, language, validation, and operational feedback in the right way.
+
+## Closing
+
+A decade ago, practical document AI often meant OCR plus a pile of rules. Today it can mean VLMs, LLMs, modern OCR, structured outputs, validators, and agentic orchestration. That is real progress.
+
+But the deepest continuity is that useful document AI has always depended on respecting the long tail: visual variation, semantic ambiguity, business constraints, and the need to know when the machine should stop and ask for help.
+
+The models got better. The stack got more powerful. The job, in a strangely durable way, stayed the same.
+
+## Selected references
+
+- [LayoutLM: Pre-training of Text and Layout for Document Image Understanding](https://arxiv.org/abs/1912.13318)
+- [LayoutLMv3: Pre-training for Document AI with Unified Text and Image Masking](https://arxiv.org/abs/2204.08387)
+- [DocVQA](https://www.docvqa.org/)
+- [DocLayNet: A Large Human-Annotated Dataset for Document-Layout Analysis](https://arxiv.org/abs/2206.01062)
+- [PubTabNet: A Large-scale Dataset for Image-based Table Recognition](https://arxiv.org/abs/1911.10683)
+- [Hugging Face Transformers](https://huggingface.co/docs/transformers/index)
+- [TRL: Transformer Reinforcement Learning](https://huggingface.co/docs/trl/index)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Content-only change adding a new `posts/` entry; no application logic or infrastructure is modified.
> 
> **Overview**
> Adds a new Quarto blog post at `posts/20260331-practical-doc-ai/index.qmd` titled *“Learnings from a Decade of Document AI Work”*.
> 
> The post introduces a phased perspective (templates → detector pipelines → layout-aware transformers → foundation-model systems), includes a comparison table and a Mermaid diagram, and closes with references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fb7d15cb26ba0892d7d9bd8f8e5cc7186b2bb4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->